### PR TITLE
Add MultiEWMA to make Meter updates atomic

### DIFF
--- a/ewma_test.go
+++ b/ewma_test.go
@@ -11,72 +11,70 @@ func BenchmarkEWMA(b *testing.B) {
 	}
 }
 
+var ewmaRates1 = []float64{
+	0.6,
+	0.22072766470286553,
+	0.08120116994196772,
+	0.029872241020718428,
+	0.01098938333324054,
+	0.004042768199451294,
+	0.0014872513059998212,
+	0.0005471291793327122,
+	0.00020127757674150815,
+	7.404588245200814e-05,
+	2.7239957857491083e-05,
+	1.0021020474147462e-05,
+	3.6865274119969525e-06,
+	1.3561976441886433e-06,
+	4.989172314621449e-07,
+	1.8354139230109722e-07,
+}
+var ewmaRates5 = []float64{
+	0.6,
+	0.49123845184678905,
+	0.4021920276213837,
+	0.32928698165641596,
+	0.269597378470333,
+	0.2207276647028654,
+	0.18071652714732128,
+	0.14795817836496392,
+	0.12113791079679326,
+	0.09917933293295193,
+	0.08120116994196763,
+	0.06648189501740036,
+	0.05443077197364752,
+	0.04456414692860035,
+	0.03648603757513079,
+	0.0298722410207183831020718428,
+}
+var ewmaRates15 = []float64{
+	0.6,
+	0.5613041910189706,
+	0.5251039914257684,
+	0.4912384518467888184678905,
+	0.459557003018789,
+	0.4299187863442732,
+	0.4021920276213831,
+	0.37625345116383313,
+	0.3519877317060185,
+	0.3292869816564153165641596,
+	0.3080502714195546,
+	0.2881831806538789,
+	0.26959737847033216,
+	0.2522102307052083,
+	0.23594443252115815,
+	0.2207276647028646247028654470286553,
+}
+
 func TestEWMA1(t *testing.T) {
 	a := NewEWMA1()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.22072766470286553 != rate {
-		t.Errorf("1 minute a.Rate(): 0.22072766470286553 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.08120116994196772 != rate {
-		t.Errorf("2 minute a.Rate(): 0.08120116994196772 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.029872241020718428 != rate {
-		t.Errorf("3 minute a.Rate(): 0.029872241020718428 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.01098938333324054 != rate {
-		t.Errorf("4 minute a.Rate(): 0.01098938333324054 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.004042768199451294 != rate {
-		t.Errorf("5 minute a.Rate(): 0.004042768199451294 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.0014872513059998212 != rate {
-		t.Errorf("6 minute a.Rate(): 0.0014872513059998212 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.0005471291793327122 != rate {
-		t.Errorf("7 minute a.Rate(): 0.0005471291793327122 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.00020127757674150815 != rate {
-		t.Errorf("8 minute a.Rate(): 0.00020127757674150815 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 7.404588245200814e-05 != rate {
-		t.Errorf("9 minute a.Rate(): 7.404588245200814e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 2.7239957857491083e-05 != rate {
-		t.Errorf("10 minute a.Rate(): 2.7239957857491083e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 1.0021020474147462e-05 != rate {
-		t.Errorf("11 minute a.Rate(): 1.0021020474147462e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 3.6865274119969525e-06 != rate {
-		t.Errorf("12 minute a.Rate(): 3.6865274119969525e-06 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 1.3561976441886433e-06 != rate {
-		t.Errorf("13 minute a.Rate(): 1.3561976441886433e-06 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 4.989172314621449e-07 != rate {
-		t.Errorf("14 minute a.Rate(): 4.989172314621449e-07 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 1.8354139230109722e-07 != rate {
-		t.Errorf("15 minute a.Rate(): 1.8354139230109722e-07 != %v\n", rate)
+	for minute, expectedRate := range ewmaRates1 {
+		if rate := a.Rate(); expectedRate != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, expectedRate, rate)
+		}
+		elapseMinute(a)
 	}
 }
 
@@ -84,68 +82,11 @@ func TestEWMA5(t *testing.T) {
 	a := NewEWMA5()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.49123845184678905 != rate {
-		t.Errorf("1 minute a.Rate(): 0.49123845184678905 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.4021920276213837 != rate {
-		t.Errorf("2 minute a.Rate(): 0.4021920276213837 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.32928698165641596 != rate {
-		t.Errorf("3 minute a.Rate(): 0.32928698165641596 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.269597378470333 != rate {
-		t.Errorf("4 minute a.Rate(): 0.269597378470333 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.2207276647028654 != rate {
-		t.Errorf("5 minute a.Rate(): 0.2207276647028654 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.18071652714732128 != rate {
-		t.Errorf("6 minute a.Rate(): 0.18071652714732128 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.14795817836496392 != rate {
-		t.Errorf("7 minute a.Rate(): 0.14795817836496392 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.12113791079679326 != rate {
-		t.Errorf("8 minute a.Rate(): 0.12113791079679326 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.09917933293295193 != rate {
-		t.Errorf("9 minute a.Rate(): 0.09917933293295193 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.08120116994196763 != rate {
-		t.Errorf("10 minute a.Rate(): 0.08120116994196763 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.06648189501740036 != rate {
-		t.Errorf("11 minute a.Rate(): 0.06648189501740036 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.05443077197364752 != rate {
-		t.Errorf("12 minute a.Rate(): 0.05443077197364752 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.04456414692860035 != rate {
-		t.Errorf("13 minute a.Rate(): 0.04456414692860035 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.03648603757513079 != rate {
-		t.Errorf("14 minute a.Rate(): 0.03648603757513079 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.0298722410207183831020718428 != rate {
-		t.Errorf("15 minute a.Rate(): 0.0298722410207183831020718428 != %v\n", rate)
+	for minute, expectedRate := range ewmaRates5 {
+		if rate := a.Rate(); expectedRate != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, expectedRate, rate)
+		}
+		elapseMinute(a)
 	}
 }
 
@@ -153,68 +94,11 @@ func TestEWMA15(t *testing.T) {
 	a := NewEWMA15()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.5613041910189706 != rate {
-		t.Errorf("1 minute a.Rate(): 0.5613041910189706 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.5251039914257684 != rate {
-		t.Errorf("2 minute a.Rate(): 0.5251039914257684 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.4912384518467888184678905 != rate {
-		t.Errorf("3 minute a.Rate(): 0.4912384518467888184678905 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.459557003018789 != rate {
-		t.Errorf("4 minute a.Rate(): 0.459557003018789 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.4299187863442732 != rate {
-		t.Errorf("5 minute a.Rate(): 0.4299187863442732 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.4021920276213831 != rate {
-		t.Errorf("6 minute a.Rate(): 0.4021920276213831 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.37625345116383313 != rate {
-		t.Errorf("7 minute a.Rate(): 0.37625345116383313 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.3519877317060185 != rate {
-		t.Errorf("8 minute a.Rate(): 0.3519877317060185 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.3292869816564153165641596 != rate {
-		t.Errorf("9 minute a.Rate(): 0.3292869816564153165641596 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.3080502714195546 != rate {
-		t.Errorf("10 minute a.Rate(): 0.3080502714195546 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.2881831806538789 != rate {
-		t.Errorf("11 minute a.Rate(): 0.2881831806538789 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.26959737847033216 != rate {
-		t.Errorf("12 minute a.Rate(): 0.26959737847033216 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.2522102307052083 != rate {
-		t.Errorf("13 minute a.Rate(): 0.2522102307052083 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.23594443252115815 != rate {
-		t.Errorf("14 minute a.Rate(): 0.23594443252115815 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); 0.2207276647028646247028654470286553 != rate {
-		t.Errorf("15 minute a.Rate(): 0.2207276647028646247028654470286553 != %v\n", rate)
+	for minute, expectedRate := range ewmaRates15 {
+		if rate := a.Rate(); expectedRate != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, expectedRate, rate)
+		}
+		elapseMinute(a)
 	}
 }
 

--- a/meter.go
+++ b/meter.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -112,96 +113,104 @@ func (NilMeter) Snapshot() Meter { return NilMeter{} }
 
 // StandardMeter is the standard implementation of a Meter.
 type StandardMeter struct {
-	lock        sync.RWMutex
-	snapshot    *MeterSnapshot
-	a1, a5, a15 EWMA
-	startTime   time.Time
+	lock      sync.RWMutex // The lock applies to the snapshot only
+	snapshot  *MeterSnapshot
+	count     int64
+	a         MultiEWMA
+	startTime time.Time
 }
 
 func newStandardMeter() *StandardMeter {
 	return &StandardMeter{
 		snapshot:  &MeterSnapshot{},
-		a1:        NewEWMA1(),
-		a5:        NewEWMA5(),
-		a15:       NewEWMA15(),
+		a:         NewMultiEWMA(),
 		startTime: time.Now(),
 	}
 }
 
 // Count returns the number of events recorded.
 func (m *StandardMeter) Count() int64 {
-	m.lock.RLock()
-	count := m.snapshot.count
-	m.lock.RUnlock()
-	return count
+	return atomic.LoadInt64(&m.count)
 }
 
 // Mark records the occurance of n events.
 func (m *StandardMeter) Mark(n int64) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.snapshot.count += n
-	m.a1.Update(n)
-	m.a5.Update(n)
-	m.a15.Update(n)
-	m.updateSnapshot()
+	atomic.AddInt64(&m.count, n)
+	m.a.Update(n)
 }
 
 // Rate1 returns the one-minute moving average rate of events per second.
-func (m *StandardMeter) Rate1() float64 {
-	m.lock.RLock()
-	rate1 := m.snapshot.rate1
-	m.lock.RUnlock()
-	return rate1
+func (m *StandardMeter) Rate1() (rate1 float64) {
+	m.withUpdatedSnapshot(func(snapshot *MeterSnapshot) {
+		rate1 = snapshot.rate1
+	})
+	return
 }
 
 // Rate5 returns the five-minute moving average rate of events per second.
-func (m *StandardMeter) Rate5() float64 {
-	m.lock.RLock()
-	rate5 := m.snapshot.rate5
-	m.lock.RUnlock()
-	return rate5
+func (m *StandardMeter) Rate5() (rate5 float64) {
+	m.withUpdatedSnapshot(func(snapshot *MeterSnapshot) {
+		rate5 = snapshot.rate5
+	})
+	return
 }
 
 // Rate15 returns the fifteen-minute moving average rate of events per second.
-func (m *StandardMeter) Rate15() float64 {
-	m.lock.RLock()
-	rate15 := m.snapshot.rate15
-	m.lock.RUnlock()
-	return rate15
+func (m *StandardMeter) Rate15() (rate15 float64) {
+	m.withUpdatedSnapshot(func(snapshot *MeterSnapshot) {
+		rate15 = snapshot.rate15
+	})
+	return
 }
 
 // RateMean returns the meter's mean rate of events per second.
-func (m *StandardMeter) RateMean() float64 {
-	m.lock.RLock()
-	rateMean := m.snapshot.rateMean
-	m.lock.RUnlock()
-	return rateMean
+func (m *StandardMeter) RateMean() (rateMean float64) {
+	m.withUpdatedSnapshot(func(snapshot *MeterSnapshot) {
+		rateMean = snapshot.rateMean
+	})
+	return
 }
 
 // Snapshot returns a read-only copy of the meter.
-func (m *StandardMeter) Snapshot() Meter {
+func (m *StandardMeter) Snapshot() (s Meter) {
+	m.withUpdatedSnapshot(func(snapshot *MeterSnapshot) {
+		s = snapshot
+	})
+	return
+}
+
+// Runs the given function with at least a read lock on the snapshot argument.
+func (m *StandardMeter) withUpdatedSnapshot(f func(*MeterSnapshot)) {
+	// avoid exclusive access if possible
 	m.lock.RLock()
-	snapshot := *m.snapshot
+	if atomic.LoadInt64(&m.count) == m.snapshot.count {
+		f(m.snapshot)
+		m.lock.RUnlock()
+		return
+	}
 	m.lock.RUnlock()
-	return &snapshot
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if atomic.LoadInt64(&m.count) != m.snapshot.count {
+		m.updateSnapshot()
+	}
+	f(m.snapshot)
 }
 
 func (m *StandardMeter) updateSnapshot() {
 	// should run with write lock held on m.lock
 	snapshot := m.snapshot
-	snapshot.rate1 = m.a1.Rate()
-	snapshot.rate5 = m.a5.Rate()
-	snapshot.rate15 = m.a15.Rate()
+	snapshot.count = atomic.LoadInt64(&m.count)
+	snapshot.rate1 = m.a.Rate1()
+	snapshot.rate5 = m.a.Rate5()
+	snapshot.rate15 = m.a.Rate15()
 	snapshot.rateMean = float64(snapshot.count) / time.Since(m.startTime).Seconds()
 }
 
 func (m *StandardMeter) tick() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.a1.Tick()
-	m.a5.Tick()
-	m.a15.Tick()
+	m.a.Tick()
 	m.updateSnapshot()
 }
 

--- a/meter_test.go
+++ b/meter_test.go
@@ -30,7 +30,8 @@ func TestMeterDecay(t *testing.T) {
 	go ma.tick()
 	m.Mark(1)
 	rateMean := m.RateMean()
-	time.Sleep(1)
+	time.Sleep(time.Millisecond)
+	ma.ticker.Stop()
 	if m.RateMean() >= rateMean {
 		t.Error("m.RateMean() didn't decrease")
 	}

--- a/multiewma.go
+++ b/multiewma.go
@@ -1,0 +1,155 @@
+package metrics
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// MultiEWMAs continuously calculate an exponentially-weighted moving average
+// of several intervals, based on an outside source of clock ticks.
+type MultiEWMA interface {
+	Rate1() float64
+	Rate5() float64
+	Rate15() float64
+	Snapshot() MultiEWMA
+	Tick()
+	Update(int64)
+}
+
+const (
+	multiEWMARate1 = iota
+	multiEWMARate5
+	multiEWMARate15
+)
+
+// NewMultiEWMAWithAlphas constructs a new MultiEWMA with the given alphas.
+func NewMultiEWMAWithAlphas(alphas [3]float64) MultiEWMA {
+	if UseNilMetrics {
+		return NilMultiEWMA{}
+	}
+	return &StandardMultiEWMA{alphas: alphas}
+}
+
+// NewMultiEWMA constructs a new MultiEWMA for a one, five and fifteen-minute
+// moving average.
+func NewMultiEWMA() MultiEWMA {
+	return NewMultiEWMAWithAlphas([3]float64{
+		1 - math.Exp(oneMinuteDecay),
+		1 - math.Exp(fiveMinuteDecay),
+		1 - math.Exp(fifteenMinuteDecay)})
+}
+
+// MultiEWMASnapshot is a read-only copy of another MultiEWMA.
+type MultiEWMASnapshot [3]float64
+
+// Rate1 returns the rate of events per second in the first interval (by
+// default, one-minute) at the time the snapshot was taken.
+func (a MultiEWMASnapshot) Rate1() float64 { return float64(a[multiEWMARate1]) }
+
+// Rate5 returns the rate of events per second in the first interval (by
+// default, five-minute) at the time the snapshot was taken.
+func (a MultiEWMASnapshot) Rate5() float64 { return float64(a[multiEWMARate5]) }
+
+// Rate15 returns the rate of events per second in the first interval (by
+// default, fifteen-minute) at the time the snapshot was taken.
+func (a MultiEWMASnapshot) Rate15() float64 { return float64(a[multiEWMARate15]) }
+
+// Snapshot returns the snapshot.
+func (a MultiEWMASnapshot) Snapshot() MultiEWMA { return a }
+
+// Tick panics.
+func (MultiEWMASnapshot) Tick() {
+	panic("Tick called on an MultiEWMASnapshot")
+}
+
+// Update panics.
+func (MultiEWMASnapshot) Update(int64) {
+	panic("Update called on an MultiEWMASnapshot")
+}
+
+// NilMultiEWMA is a no-op MultiEWMA.
+type NilMultiEWMA struct{}
+
+// Rate1 is a no-op.
+func (NilMultiEWMA) Rate1() float64 { return 0.0 }
+
+// Rate5 is a no-op.
+func (NilMultiEWMA) Rate5() float64 { return 0.0 }
+
+// Rate15 is a no-op.
+func (NilMultiEWMA) Rate15() float64 { return 0.0 }
+
+// Snapshot is a no-op.
+func (NilMultiEWMA) Snapshot() MultiEWMA { return NilMultiEWMA{} }
+
+// Tick is a no-op.
+func (NilMultiEWMA) Tick() {}
+
+// Update is a no-op.
+func (NilMultiEWMA) Update(n int64) {}
+
+// StandardMultiEWMA is the standard implementation of an EWMA and tracks the number
+// of uncounted events and processes them on each tick.  It uses the
+// sync/atomic package to manage uncounted events.
+type StandardMultiEWMA struct {
+	uncounted int64 // /!\ this should be the first member to ensure 64-bit alignment
+	alphas    [3]float64
+	rates     [3]float64
+	init      bool
+	mutex     sync.Mutex
+}
+
+// Rate returns a moving average rate of events per second.
+// The rate duration is specified by the index.
+func (a *StandardMultiEWMA) rateByIndex(index int) float64 {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return a.rates[index] * float64(time.Second)
+}
+
+// Rate1 returns the one-minute moving average rate of events per second.
+func (a *StandardMultiEWMA) Rate1() float64 {
+	return a.rateByIndex(multiEWMARate1)
+}
+
+// Rate5 returns the five-minute moving average rate of events per second.
+func (a *StandardMultiEWMA) Rate5() float64 {
+	return a.rateByIndex(multiEWMARate5)
+}
+
+// Rate15 returns the fifteen-minute moving average rate of events per second.
+func (a *StandardMultiEWMA) Rate15() float64 {
+	return a.rateByIndex(multiEWMARate15)
+}
+
+// Snapshot returns a read-only copy of the EWMA.
+func (a *StandardMultiEWMA) Snapshot() MultiEWMA {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return MultiEWMASnapshot(a.rates)
+}
+
+// Tick ticks the clock to update the moving average.  It assumes it is called
+// every five seconds on a single thread.
+func (a *StandardMultiEWMA) Tick() {
+	instantRate := tickEWMA(&a.uncounted)
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	if a.init {
+		for index := range a.rates {
+			a.rates[index] = updateEWMARate(a.rates[index], a.alphas[index], instantRate)
+		}
+	} else {
+		a.init = true
+		for index, _ := range a.rates {
+			a.rates[index] = instantRate
+		}
+	}
+}
+
+// Update adds n uncounted events.
+func (a *StandardMultiEWMA) Update(n int64) {
+	atomic.AddInt64(&a.uncounted, n)
+}

--- a/multiewma_test.go
+++ b/multiewma_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import "testing"
+
+func BenchmarkMultiEWMA(b *testing.B) {
+	a := NewMultiEWMA()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.Update(1)
+		a.Tick()
+	}
+}
+
+func TestMultiEWMA(t *testing.T) {
+	a := NewMultiEWMA()
+	a.Update(3)
+	a.Tick()
+	for minute, _ := range ewmaRates1 {
+		if rate := a.Rate1(); ewmaRates1[minute] != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, ewmaRates1[minute], rate)
+		}
+		if rate := a.Rate5(); ewmaRates5[minute] != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, ewmaRates5[minute], rate)
+		}
+		if rate := a.Rate15(); ewmaRates15[minute] != rate {
+			t.Errorf("%v minute a.Rate(): %v != %v\n", minute, ewmaRates15[minute], rate)
+		}
+		elapseMultiEWMAMinute(a)
+	}
+}
+
+func elapseMultiEWMAMinute(a MultiEWMA) {
+	for i := 0; i < 12; i++ {
+		a.Tick()
+	}
+}


### PR DESCRIPTION
Instead of having three separate EWMA instances, use a MultiEWMA that updates
all moving-average rates simultaneously using a single event counter. Locking
is not required to update the three rates.

We can remove the lock in StandardMeter with the only change in behaviour that
the (*StandardMeter).Mark function no longer increments StandardMeter.count and
MultiEWMA.uncounted atomically with respect to each other.
This only matters when ticking the meter every 5 seconds, where goroutines that
called Mark before the 5-second tick may appear to have called it after the
tick instead.
The benefit is that we avoid contention on frequently-used meters.
